### PR TITLE
feat: support rhdp deployment with templated urls/links

### DIFF
--- a/components/developer-hub.yaml
+++ b/components/developer-hub.yaml
@@ -4,6 +4,9 @@ metadata:
   namespace: default
   name: developer-hub
   description: An internal developer portal providing a Software Catalog and integrations.
+  links:
+    - url: https://backstage-backstage{{ cluster_subdomain }}
+      title: Developer Hub
 spec:
   type: dev-service
   tags:

--- a/components/gitlab.yaml
+++ b/components/gitlab.yaml
@@ -4,6 +4,9 @@ metadata:
   namespace: default
   name: gitlab
   description: Git repository and CI platform.
+  links:
+    - url: https://{{ gitlab_host }}
+      title: GitLab Console
 spec:
   type: dev-service
   lifecycle: production

--- a/components/janus-gitops.yaml
+++ b/components/janus-gitops.yaml
@@ -2,7 +2,10 @@ apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: developer-hub-gitops
-  description: OpenShift GitOps (Argo CD) cluster used to manage infrastructure.
+  description: OpenShift GitOps (Argo CD) cluster used to manage developer workloads.
+  links:
+    - url: https://argocd-server-janus-argocd{{ cluster_subdomain }}
+      title: Developer GitOps
 spec:
   type: dev-service
   lifecycle: production

--- a/components/openshift-api-server.yaml
+++ b/components/openshift-api-server.yaml
@@ -4,6 +4,9 @@ metadata:
   namespace: default
   name: openshift-api-server
   description: The API server for the OpenShift cluster.
+  links:
+    url: https://api{{ cluster_subdomain }}:6443
+    title: OpenShift API URL
 spec:
   type: service
   lifecycle: production

--- a/components/openshift-devspaces.yaml
+++ b/components/openshift-devspaces.yaml
@@ -3,6 +3,9 @@ kind: Component
 metadata:
   name: openshift-devspaces
   description: OpenShift DevSpaces - A web-based IDE
+  links:
+    - url: https://devspaces{{ cluster_subdomain }}
+      title: DevSpaces Console
 spec:
   type: dev-service
   lifecycle: production

--- a/components/openshift-gitops.yaml
+++ b/components/openshift-gitops.yaml
@@ -3,6 +3,9 @@ kind: Component
 metadata:
   name: openshift-gitops
   description: OpenShift GitOps (Argo CD) cluster used to manage infrastructure.
+  links:
+  - url: https://argocd-server-openshift-gitops{{ cluster_subdomain }}
+    title: Infrastructure GitOps
 spec:
   type: service
   lifecycle: production

--- a/components/quay.yaml
+++ b/components/quay.yaml
@@ -5,7 +5,7 @@ metadata:
   name: quay
   description: A container image registry service.
   links:
-    - url: https://quay-GUID.apps.cluster-GUID.GUID.CLUSTER.opentlc.com/
+    - url: https://{{ quay_host }}
       title: Quay Console
 spec:
   type: image-registry

--- a/location.apis.yaml
+++ b/location.apis.yaml
@@ -1,7 +1,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Location
 metadata:
-  name: apis
+  name: rhdh-platform-apis
 spec:
   type: url
   target: ./apis/**/*.yaml

--- a/location.components.yaml
+++ b/location.components.yaml
@@ -1,7 +1,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Location
 metadata:
-  name: components
+  name: rhdh-platform-components
 spec:
   type: url
   target: ./components/**/*.yaml

--- a/location.domains.yaml
+++ b/location.domains.yaml
@@ -1,7 +1,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Location
 metadata:
-  name: domains
+  name: rhdh-platform-domains
 spec:
   type: url
   target: ./domains/**/*.yaml

--- a/location.resources.yaml
+++ b/location.resources.yaml
@@ -1,7 +1,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Location
 metadata:
-  name: resources
+  name: rhdh-platform-resources
 spec:
   type: url
   target: ./resources/**/*.yaml

--- a/location.systems.yaml
+++ b/location.systems.yaml
@@ -1,7 +1,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Location
 metadata:
-  name: systems
+  name: rhdh-platform-systems
 spec:
   type: url
   target: ./systems/**/*.yaml

--- a/locations.yaml
+++ b/locations.yaml
@@ -1,7 +1,7 @@
 apiVersion: backstage.io/v1alpha1
 kind: Location
 metadata:
-  name: all-locations
+  name: rhdh-platform-entities
 spec:
   targets: 
     - ./location.domains.yaml

--- a/systems/openshift-dev-cluster.yaml
+++ b/systems/openshift-dev-cluster.yaml
@@ -3,6 +3,9 @@ kind: System
 metadata:
   name: dev-cluster-services
   description: Services running on the development OpenShift cluster.
+  links:
+    - url: https://console-openshift-console{{ cluster_subdomain }}
+      title: OpenShift Console
 spec:
   owner: group:rhdh
   type: openshift-system


### PR DESCRIPTION
Relevant agnosticd section https://github.com/redhat-cop/agnosticd/blob/development/ansible/roles_ocp_workloads/ocp4_workload_redhat_developer_hub/tasks/setup_templates.yml#L37-L47